### PR TITLE
filter bug fix

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -88,6 +88,11 @@ const filterByRating = function() {
     e.preventDefault();
     let filterSelection = parseInt($('#rating-options').val());
     
+    /* 
+      allows user to make multiple filter selections by removing
+      display:none settings each time a rating filter selection
+      is made 
+    */
     $('*#individual-bookmark').each(function(index, element) { 
       element.style.display='block';
     });

--- a/src/store.js
+++ b/src/store.js
@@ -87,6 +87,10 @@ const filterByRating = function() {
   $('#rating-options').on('change', e => {
     e.preventDefault();
     let filterSelection = parseInt($('#rating-options').val());
+    
+    $('*#individual-bookmark').each(function(index, element) { 
+      element.style.display='block';
+    });
 
     for(let i = 0; i < items.length; i++) {
       let ratingNumber = parseInt(items[i].rating);


### PR DESCRIPTION
when making a filter selection, you could not make another filter selection with a lesser rating.
for example, if you filtered by 4 stars, you would display 4 and 5 star bookmarks. if you then selected 2 stars, you *should* display 2, 3, 4, and 5 star bookmarks, but instead it still only displayed 4 and 5 star bookmarks.